### PR TITLE
Added GitHub Discussion Autoresponder and Updated Links to Discourse in Docs and README

### DIFF
--- a/.github/workflows/discussion_autoresponder.yml
+++ b/.github/workflows/discussion_autoresponder.yml
@@ -1,0 +1,18 @@
+name: Discussion Autoresponder
+
+on:
+  discussion:
+    types: [created]
+
+jobs:
+  autorespond:
+    name: Autorespond to New Discussions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Discussion Autoresponder
+        uses: wesleyscholl/discussion-auto-responder@v1.0.8
+        with:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          comment_body: "Hi! We have now moved our discussions to [Discourse](https://pybamm.discourse.group/). Please post your question there."
+          delay_milliseconds: 0

--- a/README.md
+++ b/README.md
@@ -166,8 +166,10 @@ If you'd like to help us develop PyBaMM by adding new methods, writing documenta
 
 ## 📫 Get in touch
 
-For any questions, comments, suggestions or bug reports, please see the
-[contact page](https://www.pybamm.org/community).
+For any questions, comments, suggestions or bug reports, please visit:
+
+- Our [Contact Page](https://www.pybamm.org/community)
+- Our [Discussion Forum](https://pybamm.discourse.group/)
 
 ## 📃 License
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ PyBaMM documentation
 `Installation <source/user_guide/installation/index.html>`_ |
 `Source Repository <https://github.com/pybamm-team/pybamm>`_ |
 `Issue Tracker <https://github.com/pybamm-team/pybamm/issues>`_ |
-`Discussions <https://github.com/pybamm-team/pybamm/discussions>`_
+`Discussions <https://pybamm.discourse.group/>`_
 
 PyBaMM (Python Battery Mathematical Modelling) is an open-source battery simulation package
 written in Python. Our mission is to accelerate battery modelling research by


### PR DESCRIPTION
# GitHub Discussion Autoresponder Integration

# Description

This PR introduces a commit that adds an autoresponder to GitHub discussions, which redirects users to the [Discourse forum](https://pybamm.discourse.group/). The changes include the addition of the discussion_responder.yml GitHub Action to manage automatic responses to new discussions, updates to the documentation to guide users toward the Discourse forum for further discussion, and the inclusion of a link to the Discourse forum in the README.md file.

Fixes: #4647 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:

- [x] No style issues: `$ pre-commit run` (or `$ nox -s pre-commit`) (see [CONTRIBUTING.md](https://github.com/pybamm-team/PyBaMM/blob/develop/CONTRIBUTING.md#installing-and-using-pre-commit) for how to set this up to run automatically when committing locally, in just two lines of code)
- [x] All tests pass: `$ python -m pytest` (or `$ nox -s tests`)
- [x] The documentation builds: `$ python -m pytest --doctest-plus src` (or `$ nox -s doctests`)

## Further checks:

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added that prove fix is effective or that feature works

https://github.com/user-attachments/assets/52adb709-dde8-4090-ba8d-40ba97dd2555

## Since I don't have access to trigger discussions in the PyBaMM repository, I have tested the autoresponder in a separate test repository.

https://github.com/user-attachments/assets/c1d51022-9354-49f9-b4b6-ffe3fed43cbd

